### PR TITLE
fix: removes scrolling caused by overflow

### DIFF
--- a/web/src/lib/Components/Table.svelte
+++ b/web/src/lib/Components/Table.svelte
@@ -13,4 +13,4 @@
   })
 </script>
 
-<div id={tableId} class="h-3/4 w-3/4 ag-theme-alpine-dark" />
+<div id={tableId} class="h-3/4 w-9/10 ag-theme-alpine-dark" />

--- a/web/src/routes/admin/index.svelte
+++ b/web/src/routes/admin/index.svelte
@@ -15,11 +15,11 @@
 
     <!-- Cards -->
     <div class="grid gap-6 mb-8 md:grid-cols-1 xl:grid-cols-3">
-      <Card title="Pipelines" num="50" link="/pipelines" />
+      <Card title="Pipelines" num={50} link="/pipelines" />
       <!-- Users -->
-      <Card title="Repositories" num="20" link="/repositories" />
+      <Card title="Repositories" num={20} link="/repositories" />
       <!-- Documents -->
-      <Card title="External secrets" num="12" link="/repositories" />
+      <Card title="External secrets" num={12} link="/repositories" />
     </div>
     <div class="px-4 py-3 mb-8 rounded-lg flex flex-row-reverse">
       <div

--- a/web/src/routes/admin/pipelines/index.svelte
+++ b/web/src/routes/admin/pipelines/index.svelte
@@ -78,11 +78,11 @@
   <title>Pipelines</title>
 </svelte:head>
 
-<main class="h-full overflow-y-auto">
-  <div class="container px-6 mx-auto grid">
+<main class="h-full overflow-hidden">
+  <div class="container px-6 mx-auto grid overflow-hidden">
     <h2 class="my-6 text-2xl font-semibold text-gray-700 dark:text-gray-200">Pipelines</h2>
     <!-- New Table -->
-    <div class="w-screen h-screen overflow-hidden rounded-lg shadow-xs">
+    <div class="w-full h-screen overflow-hidden rounded-lg shadow-xs">
       <Table tableId="pipeline-grid" {gridOptions} />
     </div>
   </div>

--- a/web/src/routes/admin/repositories/index.svelte
+++ b/web/src/routes/admin/repositories/index.svelte
@@ -56,11 +56,11 @@
   <title>Repositories</title>
 </svelte:head>
 
-<main class="h-full overflow-y-auto">
-  <div class="container px-6 mx-auto grid">
+<main class="h-full overflow-hidden">
+  <div class="container px-6 mx-auto grid overflow-hidden">
     <h2 class="my-6 text-2xl font-semibold text-gray-700 dark:text-gray-200">Repositories</h2>
     <!-- New Table -->
-    <div class="w-screen h-screen overflow-hidden rounded-lg shadow-xs">
+    <div class="w-full h-screen overflow-hidden rounded-lg shadow-xs">
       <Table tableId="repo-grid" {gridOptions} />
     </div>
   </div>


### PR DESCRIPTION
This PR fixes:
- removes scrolling caused by the overflow of the table component
        - adds `overflow-hidden` to stop vertical scroll
        - changes the width to `100%` instead of `100vw`
        - increases the width of table
- the num(in `admin/index`) is a number, passing a string gives an error

Signed-off-by: rajatgupta24 <rajat2411gupta@gmail.com>