### PR TITLE
fix: disable pre-rendering to fix production build

### DIFF
--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -20,6 +20,9 @@ const config = {
     files: {
       routes: `src/routes/${routeFolder}`,
     },
+    prerender: {
+      enabled: false,
+    },
     vite: {
       resolve: {
         alias: {


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Fixes issue with npm run build (when running frontend build with no backend server running in the background):
```
FetchError: request to http://localhost:8080/api/v1/repositories failed, reason: connect ECONNREFUSED 127.0.0.1:8080
    at ClientRequest.<anonymous> (file:///home/ankitm123/work/jx-ui/web/node_modules/@sveltejs/kit/dist/install-fetch.js:6246:11)
    at ClientRequest.emit (node:events:390:28)
    at Socket.socketErrorListener (node:_http_client:447:9)
    at Socket.emit (node:events:390:28)
    at emitErrorNT (node:internal/streams/destroy:157:8)
    at emitErrorCloseNT (node:internal/streams/destroy:122:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
> 500 /repositories
    at file:///home/ankitm123/work/jx-ui/web/node_modules/@sveltejs/kit/dist/chunks/index5.js:409:11
    at visit (file:///home/ankitm123/work/jx-ui/web/node_modules/@sveltejs/kit/dist/chunks/index5.js:583:5)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
make: *** [Makefile:9: frontend] Error 1
```