### PR TITLE
fix: npm run test failing

### DIFF
--- a/web/src/lib/Templates/Admin/Header.svelte
+++ b/web/src/lib/Templates/Admin/Header.svelte
@@ -166,7 +166,7 @@
               <li class="flex">
                 <a
                   class="inline-flex items-center w-full px-2 py-1 text-sm font-semibold transition-colors duration-150 rounded-md hover:bg-gray-100 hover:text-gray-800 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-                  href="#"
+                  href="/"
                 >
                   <svg
                     class="w-4 h-4 mr-3"
@@ -186,7 +186,7 @@
               <li class="flex">
                 <a
                   class="inline-flex items-center w-full px-2 py-1 text-sm font-semibold transition-colors duration-150 rounded-md hover:bg-gray-100 hover:text-gray-800 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-                  href="#"
+                  href="/"
                 >
                   <svg
                     class="w-4 h-4 mr-3"
@@ -209,7 +209,7 @@
               <li class="flex">
                 <a
                   class="inline-flex items-center w-full px-2 py-1 text-sm font-semibold transition-colors duration-150 rounded-md hover:bg-gray-100 hover:text-gray-800 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-                  href="#"
+                  href="/"
                 >
                   <svg
                     class="w-4 h-4 mr-3"

--- a/web/src/lib/cellRenderer.test.ts
+++ b/web/src/lib/cellRenderer.test.ts
@@ -12,4 +12,5 @@ it('returns only text with link if link is invalid', () => {
   expect(output).toContain('Jenkins X')
   // ToDo: test that it does not contain a <a> tag
   expect(output).not.toContain('http')
+  expect(output).not.toContain('<a href="" >Jenkins X</a>')
 })

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -1,6 +1,7 @@
 import preprocess from 'svelte-preprocess'
 import { resolve } from 'path'
 import adapter from '@sveltejs/adapter-static'
+import { configDefaults } from 'vitest/config'
 
 let routeFolder = process.env.ROUTE_FOLDER
 
@@ -43,6 +44,7 @@ const config = {
         },
         globals: true,
         setupFiles: ['src/setupTests.ts'],
+        exclude: [...configDefaults.exclude, 'e2e/*'],
       },
     },
   },


### PR DESCRIPTION
- This adds a exclude field in svelte.config.js, this will prevent vite from running playwright tests.
- Adds a new test case from cellRenderer.ts, checks if there is a <a> or not.