### PR TITLE
fix: modal popup without clicking

### DIFF
--- a/web/src/lib/cellRenderer.ts
+++ b/web/src/lib/cellRenderer.ts
@@ -23,7 +23,7 @@ export const BTNInColumnCell = (status: string, owner: string, branch: string, r
       build
     }
 
-    p.addEventListener('click', clickHandler(name, pipeline));
+    p.addEventListener('click', () => clickHandler(name, pipeline));
     return p;
   }
   return null


### PR DESCRIPTION
The clickHandler is getting executed automatically, making the modal show without clicking.
Making it an arrow function fixes it.