### PR TITLE
refactor: upgrade sveltekit to 1.0.0-next.502

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,7 +29,7 @@
         "@storybook/addon-svelte-csf": "^2.0.3",
         "@storybook/svelte": "^6.4.22",
         "@sveltejs/adapter-static": "1.0.0-next.43",
-        "@sveltejs/kit": "1.0.0-next.497",
+        "@sveltejs/kit": "1.0.0-next.502",
         "@tailwindcss/forms": "^0.4.0",
         "@tailwindcss/line-clamp": "^0.3.1",
         "@tailwindcss/typography": "^0.5.2",
@@ -4706,9 +4706,9 @@
       "dev": true
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.497",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.497.tgz",
-      "integrity": "sha512-7OPZ7/CnKz2M9D5mEFpVQywMdKLX3aVBnw7uLrdxCVkmPlgLCfh5ZfIYGkw/kfUpGTH9+8dhC2qoWnOhmo2k/g==",
+      "version": "1.0.0-next.502",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.502.tgz",
+      "integrity": "sha512-S2MLydojG1G9mQXcM0cAY6CyYtPQ3QeiTTxQe/TQbV1r1zTYwqRea9DVeRJd3EECWvWM46BnW/6yEAs9N5GvXg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -26406,9 +26406,9 @@
       "dev": true
     },
     "@sveltejs/kit": {
-      "version": "1.0.0-next.497",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.497.tgz",
-      "integrity": "sha512-7OPZ7/CnKz2M9D5mEFpVQywMdKLX3aVBnw7uLrdxCVkmPlgLCfh5ZfIYGkw/kfUpGTH9+8dhC2qoWnOhmo2k/g==",
+      "version": "1.0.0-next.502",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.502.tgz",
+      "integrity": "sha512-S2MLydojG1G9mQXcM0cAY6CyYtPQ3QeiTTxQe/TQbV1r1zTYwqRea9DVeRJd3EECWvWM46BnW/6yEAs9N5GvXg==",
       "dev": true,
       "requires": {
         "@sveltejs/vite-plugin-svelte": "^1.0.5",

--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
     "@storybook/addon-svelte-csf": "^2.0.3",
     "@storybook/svelte": "^6.4.22",
     "@sveltejs/adapter-static": "1.0.0-next.43",
-    "@sveltejs/kit": "1.0.0-next.497",
+    "@sveltejs/kit": "1.0.0-next.502",
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/line-clamp": "^0.3.1",
     "@tailwindcss/typography": "^0.5.2",


### PR DESCRIPTION
Update svelteKit to 1.0.0-next.502
Visit changelog here: https://github.com/sveltejs/kit/releases