### PR TITLE
fix: add sr to resource to list in values.yaml

### DIFF
--- a/charts/jx-ui/values.yaml
+++ b/charts/jx-ui/values.yaml
@@ -116,6 +116,7 @@ role:
     resources:
     - pipelineactivities
     - pipelinestructures
+    - sourcerepositories
     verbs:
     - list
     - watch


### PR DESCRIPTION
Earlier the repository section was giving a 404 error because the pods do not have access to source repositories, this will resolve that issue.