### PR TITLE
fix: add update to pr verbs

### DIFF
--- a/charts/jx-ui/values.yaml
+++ b/charts/jx-ui/values.yaml
@@ -130,6 +130,7 @@ role:
     - list
     - watch
     - get
+    - update
   - apiGroups:
     - ""
     resources:


### PR DESCRIPTION
To make pipelines stop from UI we need to add **update** as the verb in `tekton.dev` API group.